### PR TITLE
feat: add support for other request options

### DIFF
--- a/R/vl_isochrone.R
+++ b/R/vl_isochrone.R
@@ -25,6 +25,8 @@
 #' (see \url{https://valhalla.github.io/valhalla/api/turn-by-turn/api-reference/#costing-options}
 #' for more details about the options available for each costing model).
 #' @param server URL of the Valhalla server.
+#' @param request_options list of request options
+#' (see \url{https://valhalla.github.io/valhalla/api/isochrone/api-reference/#other-request-parameters}).
 #' @returns An sf MULTIPOLYGON object is returned with the following fields:
 #' 'metric' (the metric used, either 'time' or 'distance')
 #' and 'contour' (the value of the metric).
@@ -51,7 +53,8 @@
 #' @export
 vl_isochrone <- function(loc, times, distances,
                          costing = "auto", costing_options = list(),
-                         server = getOption("valh.server")) {
+                         server = getOption("valh.server"),
+                         request_options = list()) {
   # Handle input point(s)
   loc <- input_route(x = loc, single = TRUE, id = "loc")
   oprj <- loc$oprj
@@ -86,13 +89,33 @@ vl_isochrone <- function(loc, times, distances,
     stop("You must provide either 'times' or 'distances'.", call. = FALSE)
   }
 
+  # Warn users if they provided something in request_options that we override
+  if (is.list(request_options) && length(request_options) > 0) {
+    if ("costing" %in% names(request_options)) {
+      warning("The 'costing' parameter in 'request_options' will be ignored, as it is set by the 'costing' argument of the function.", call. = FALSE)
+    }
+    if ("costing_options" %in% names(request_options)) {
+      warning("The 'costing_options' parameter in 'request_options' will be ignored, as it is set by the 'costing_options' argument of the function.", call. = FALSE)
+    }
+    if ("locations" %in% names(request_options)) {
+      warning("The 'locations' parameter in 'request_options' will be ignored, as it is set by the 'loc' argument of the function.", call. = FALSE)
+    }
+    if ("polygons" %in% names(request_options)) {
+      warning("The 'polygons' parameter in 'request_options' will be ignored, as it is set to TRUE in the function.", call. = FALSE)
+    }
+    if ("contours" %in% names(request_options)) {
+      warning("The 'contours' parameter in 'request_options' will be ignored, as it is set by the 'times' or 'distances' argument of the function.", call. = FALSE)
+    }
+  }
+
   # Build the JSON argument of the request
-  json <- list(
+  json <- c(list(
     costing = costing,
     polygons = TRUE,
     contours = contours,
     locations = locs
-  )
+  ), request_options)
+
   if (is.list(costing_options) && length(costing_options) > 0) {
     json$costing_options <- list()
     json$costing_options[[costing]] <- costing_options

--- a/R/vl_matrix.R
+++ b/R/vl_matrix.R
@@ -35,6 +35,8 @@
 #' (see \url{https://valhalla.github.io/valhalla/api/turn-by-turn/api-reference/#costing-options}
 #' for more details about the options available for each costing model).
 #' @param server URL of the Valhalla server.
+#' @param request_options list of request options
+#' (see \url{https://valhalla.github.io/valhalla/api/matrix/api-reference/#other-request-options}).
 #' @return
 #' The output of this function is a list composed of one or two matrices
 #' and 2 data.frames
@@ -81,7 +83,8 @@
 #' @export
 vl_matrix <- function(src, dst, loc,
                       costing = "auto", costing_options = list(),
-                      server = getOption("valh.server")) {
+                      server = getOption("valh.server"),
+                      request_options = list()) {
   # Handle input points
   if (!missing(loc)) {
     dst_r <- src_r <- input_table(x = loc, id = "loc")
@@ -92,13 +95,25 @@ vl_matrix <- function(src, dst, loc,
   sources <- lapply(seq_along(src_r$lon), function(i) list(lon = src_r$lon[i], lat = src_r$lat[i]))
   targets <- lapply(seq_along(dst_r$lon), function(i) list(lon = dst_r$lon[i], lat = dst_r$lat[i]))
 
+  # Warn users if they provided something in request_options that we override
+  if (is.list(request_options) && length(request_options) > 0) {
+    if (any(names(request_options) %in% c("costing", "sources", "targets", "verbose"))) {
+      warning(paste0(
+        "You provided some parameters in 'request_options' (among 'costing', 'costing_options', 'sources', 'targets' or 'verbose')",
+        " that are overridden by the function arguments. ",
+        "Please provide these parameters directly as function arguments instead of in 'request_options'."
+      ), call. = FALSE)
+    }
+  }
+
   # Build the JSON argument of the request
-  json <- list(
+  json <- c(list(
     costing = costing,
     sources = sources,
     targets = targets,
     verbose = TRUE
-  )
+  ), request_options)
+
   if (is.list(costing_options) && length(costing_options) > 0) {
     json$costing_options <- list()
     json$costing_options[[costing]] <- costing_options

--- a/R/vl_route.R
+++ b/R/vl_route.R
@@ -46,6 +46,8 @@
 #' (see \url{https://valhalla.github.io/valhalla/api/turn-by-turn/api-reference/#costing-options}
 #' for more details about the options available for each costing model).
 #' @param server URL of the Valhalla server.
+#' @param request_options list of request options
+#' (see \url{https://valhalla.github.io/valhalla/api/turn-by-turn/api-reference/#other-request-options}).
 #' @return
 #' The output of this function is an sf LINESTRING of the shortest route.\cr
 #' It contains 4 fields: \itemize{
@@ -83,7 +85,8 @@
 #' @export
 vl_route <- function(src, dst, loc,
                      costing = "auto", costing_options = list(),
-                     server = getOption("valh.server")) {
+                     server = getOption("valh.server"),
+                     request_options = list()) {
   # Handle input points
   if (missing(loc)) {
     # From src to dst
@@ -105,11 +108,23 @@ vl_route <- function(src, dst, loc,
     locs <- lapply(seq_along(loc$lon), function(i) list(lon = loc$lon[i], lat = loc$lat[i]))
   }
 
+  # Warn users if they provided something in request_options that we override
+  if (is.list(request_options) && length(request_options) > 0) {
+    if (any(names(request_options) %in% c("locations", "costing", "costing_options"))) {
+      warning(paste0(
+        "You provided some parameters in 'request_options' (among 'locations', 'costing' or 'costing_options')",
+        " that are overridden by the function arguments. Please remove these parameters",
+        " from 'request_options' to avoid confusion."
+      ), call. = FALSE)
+    }
+  }
+
   # Build the JSON argument of the request
-  json <- list(
+  json <- c(list(
     costing = costing,
     locations = locs
-  )
+  ), request_options)
+
   if (is.list(costing_options) && length(costing_options) > 0) {
     json$costing_options <- list()
     json$costing_options[[costing]] <- costing_options

--- a/man/vl_isochrone.Rd
+++ b/man/vl_isochrone.Rd
@@ -10,7 +10,8 @@ vl_isochrone(
   distances,
   costing = "auto",
   costing_options = list(),
-  server = getOption("valh.server")
+  server = getOption("valh.server"),
+  request_options = list()
 )
 }
 \arguments{
@@ -38,6 +39,9 @@ be greater than 0.}
 for more details about the options available for each costing model).}
 
 \item{server}{URL of the Valhalla server.}
+
+\item{request_options}{list of request options
+(see \url{https://valhalla.github.io/valhalla/api/isochrone/api-reference/#other-request-parameters}).}
 }
 \value{
 An sf MULTIPOLYGON object is returned with the following fields:

--- a/man/vl_matrix.Rd
+++ b/man/vl_matrix.Rd
@@ -10,7 +10,8 @@ vl_matrix(
   loc,
   costing = "auto",
   costing_options = list(),
-  server = getOption("valh.server")
+  server = getOption("valh.server"),
+  request_options = list()
 )
 }
 \arguments{
@@ -47,6 +48,9 @@ If relevant, row names are used as identifiers.}
 for more details about the options available for each costing model).}
 
 \item{server}{URL of the Valhalla server.}
+
+\item{request_options}{list of request options
+(see \url{https://valhalla.github.io/valhalla/api/matrix/api-reference/#other-request-options}).}
 }
 \value{
 The output of this function is a list composed of one or two matrices

--- a/man/vl_route.Rd
+++ b/man/vl_route.Rd
@@ -10,7 +10,8 @@ vl_route(
   loc,
   costing = "auto",
   costing_options = list(),
-  server = getOption("valh.server")
+  server = getOption("valh.server"),
+  request_options = list()
 )
 }
 \arguments{
@@ -57,6 +58,9 @@ If relevant, row names are used as identifiers.}
 for more details about the options available for each costing model).}
 
 \item{server}{URL of the Valhalla server.}
+
+\item{request_options}{list of request options
+(see \url{https://valhalla.github.io/valhalla/api/turn-by-turn/api-reference/#other-request-options}).}
 }
 \value{
 The output of this function is an sf LINESTRING of the shortest route.\cr


### PR DESCRIPTION
In response to issue #8.

I suggest doing the following: adding an argument to support a list of request_options for the `vl_route`, `vl_matrix` and `vl_isochrones` functions. I have given careful consideration to whether we should only support `date_time` or whether we should support everything. Ultimately, I think supporting everything is a good thing, because it allows us to use the `exclude_locations` and `exclude_polygons` options, in addition to `date_time`, which can be useful (I will need to add examples to show what format is expected for these possible options).

I do not think we should add the possibility of using request options for `vl_locate` (https://valhalla.github.io/valhalla/api/locate/api-reference/#other-request-options) because we already wrap `verbose` and that is the only one that is interesting.
For `vl_optimized_route` (https://valhalla.github.io/valhalla/api/optimized/api-reference/#other-request-options) and `vl_elevation` (https://valhalla.github.io/valhalla/api/elevation/api-reference/#other-request-options), there are no interesting ones.
